### PR TITLE
added two more user permissions instagram now require

### DIFF
--- a/lib/elixtagram/oauth_strategy.ex
+++ b/lib/elixtagram/oauth_strategy.ex
@@ -4,7 +4,7 @@ defmodule Elixtagram.OAuthStrategy do
   alias OAuth2.Strategy.AuthCode
   alias Elixtagram.Config
 
-  @scopes ~w(comments relationships likes)
+  @scopes ~w(comments relationships likes public_content follower_list)
 
   # Public API
   def new do


### PR DESCRIPTION
E.g. without public_content permission one can't use Elixtagram's user_search method now.

I guess an API requires a more thorough revision/few integration tests without network mocking since Instagram had deprecated an old API [announce here](https://www.instagram.com/developer/)
