### PR TITLE
Added the `type` attribute to Media

### DIFF
--- a/lib/elixtagram/model.ex
+++ b/lib/elixtagram/model.ex
@@ -11,7 +11,7 @@ defmodule Elixtagram.Model.Tag do
 end
 
 defmodule Elixtagram.Model.Media do
-  defstruct attribution: nil, id: nil, caption: nil, comments: nil,
+  defstruct attribution: nil, id: nil, caption: nil, comments: nil, type: nil,
             images: nil, likes: nil, link: nil, location: nil, tags: nil,
             user: nil, filter: nil, created_time: nil, users_in_photo: nil
 end

--- a/test/elixtagram_test.exs
+++ b/test/elixtagram_test.exs
@@ -134,6 +134,8 @@ defmodule ElixtagramTest do
       assert Enum.member?(media.tags, "ts")
       assert media.created_time
       assert media.users_in_photo
+      assert media.type
+      assert Enum.any?(["image", "video"], fn(t) -> media.type == t end)
     end
   end
 


### PR DESCRIPTION
Instagram returns a'type' attribute that discerns the difference between 'image' and 'video' types
