### PR TITLE
Renamed :global atom for defdelegate deprecation in elixir 1.3

### DIFF
--- a/lib/elixtagram.ex
+++ b/lib/elixtagram.ex
@@ -36,7 +36,7 @@ defmodule Elixtagram do
       iex(1)> Elixtagram.configure(:global, "MY-TOKEN")
       :ok
   """
-  defdelegate configure(:global, token), to: Elixtagram.Config, as: :configure
+  defdelegate configure(scope, token), to: Elixtagram.Config, as: :configure
 
   @doc """
   Returns the url you will need to redirect a user to for them to authorise your


### PR DESCRIPTION
I've been using this fork on a production site ( using elixir 1.2.6 ) for about a week now and so far so good :)
