### PR TITLE
A fix for missed client_secret in auth_code (You must provide a client_secret error)

### DIFF
--- a/lib/elixtagram/oauth_strategy.ex
+++ b/lib/elixtagram/oauth_strategy.ex
@@ -56,6 +56,7 @@ defmodule Elixtagram.OAuthStrategy do
   end
 
   def get_token(client, params, headers) do
+    params = params |> Keyword.merge([client_secret: client.client_secret])
     client
     |> put_header("Accept", "application/json")
     |> AuthCode.get_token(params, headers)


### PR DESCRIPTION
Client secret is not passed anymore. 
https://github.com/scrogson/oauth2/commit/7d5ae395d65c08f5c053d53b7c240d85f15ee1ee
This causes 

%OAuth2.Client{authorize_url: "https://api.instagram.com/oauth/authorize/",
 client_id: "40b734125eb44a2caf3b96ce70439fe2",
 client_secret: "2e3c6ad2fff14709a792e8800cbed39c", headers: [], params: %{},
 redirect_uri: "http://localhost:4000/instagram/token",
 site: "https://api.instagram.com", strategy: Elixtagram.OAuthStrategy,
 token: %OAuth2.AccessToken{access_token: nil, expires_at: nil,
  other_params: %{"code" => 400,
    "error_message" => "You must provide a client_secret",
    "error_type" => "OAuthException"}, refresh_token: nil,
  token_type: "Bearer"}, token_method: :post,
 token_url: "https://api.instagram.com/oauth/access_token"}

Check out this thread https://github.com/scrogson/oauth2/issues/64
I did the same update for exlitagram. 
