### PR TITLE
add videos field to media model

### DIFF
--- a/lib/elixtagram/model.ex
+++ b/lib/elixtagram/model.ex
@@ -13,7 +13,8 @@ end
 defmodule Elixtagram.Model.Media do
   defstruct attribution: nil, id: nil, caption: nil, comments: nil, type: nil,
             images: nil, likes: nil, link: nil, location: nil, tags: nil,
-            user: nil, filter: nil, created_time: nil, users_in_photo: nil
+            user: nil, filter: nil, created_time: nil, users_in_photo: nil,
+            videos: nil
 end
 
 defmodule Elixtagram.Model.Location do


### PR DESCRIPTION
Hello. I've found that all media queries provide only images, even if they have `type: "video"`. In this PR `videos` field has been added to `%Elixtagram.Model.Media`. 

Here is the sample response with videos:
```
videos: %{low_bandwidth: %{height: 270,
      url: "https://scontent.cdninstagram.com/t50.2886-16/17747204_171368300050625_8951991620564156416_n.mp4",
      width: 480},
    low_resolution: %{height: 270,
      url: "https://scontent.cdninstagram.com/t50.2886-16/17747204_171368300050625_8951991620564156416_n.mp4",
      width: 480},
    standard_resolution: %{height: 360,
      url: "https://scontent.cdninstagram.com/t50.2886-16/17777682_217499228732812_4195993051723726848_n.mp4",
      width: 640}}}]
```