### PR TITLE
Implement Elixtagram.tag_recent_media_with_pagination

### DIFF
--- a/lib/elixtagram.ex
+++ b/lib/elixtagram.ex
@@ -190,6 +190,25 @@ defmodule Elixtagram do
     to: Elixtagram.API.Tags, as: :recent_media
 
   @doc """
+  Takes a tag name, a Map of params
+  Returns the n latest items in that tag among with pagination data
+
+  Search params:
+  * count
+  * min_tag_id
+  * max_tag_id
+
+  If a global access token was set with `Elixtagram.configure(:global, token)`, this
+  will be defaulted to, otherwise the client ID is used.
+
+  ## Example
+      iex(1)> Elixtagram.tag_recent_media_with_pagination("ts", %{count: 1})
+      %{data: [%Elixtagram.Model.Media{...}, %Elixtagram.Model.Media{...}], pagination: %{next_url: "https://api.instagram.com...", next_max_id: "1285565194378201229_1480448198"}}
+  """
+  defdelegate tag_recent_media_with_pagination(tag_name, params),
+    to: Elixtagram.API.Tags, as: :recent_media_with_pagination
+
+  @doc """
   Takes a tag name, a Map of params and an access token
   Returns the n latest items in that tag
 
@@ -208,6 +227,24 @@ defmodule Elixtagram do
   defdelegate tag_recent_media(tag_name, params, token),
     to: Elixtagram.API.Tags, as: :recent_media
 
+  @doc """
+  Takes a tag name, a Map of params and an access token
+  Returns the n latest items in that tag among with pagination data
+
+  Search params:
+  * count
+  * min_tag_id
+  * max_tag_id
+
+  If a global access token was set with `Elixtagram.configure(:global, token)`, this
+  will be defaulted to, otherwise the client ID is used.
+
+  ## Example
+      iex(1)> Elixtagram.tag_recent_media_with_pagination("ts", %{count: 1}, token)
+      %{data: [%Elixtagram.Model.Media{...}, %Elixtagram.Model.Media{...}], pagination: %{next_url: "https://api.instagram.com...", next_max_id: "1285565194378201229_1480448198"}}
+  """
+  defdelegate tag_recent_media_with_pagination(tag_name, params, token),
+    to: Elixtagram.API.Tags, as: :recent_media_with_pagination
 
   ## ---------- Locations
 

--- a/lib/elixtagram/api/tags.ex
+++ b/lib/elixtagram/api/tags.ex
@@ -26,8 +26,20 @@ defmodule Elixtagram.API.Tags do
   Optionally takes an access token.
   """
   def recent_media(tag_name, params, token \\ :global) do
+    recent_media_with_pagination(tag_name, params, token).data
+    |> Enum.map(&parse_media(&1))
+  end
+
+  @doc """
+  Fetch a list of n recent medias along with a pagination data for a given tag.
+  Optionally takes an access token.
+
+  Returns %{data: list_of_media, pagination: %{next_url: url, next_max_id: max_id}
+  If there are no more pages, pagination will be: %{}
+  """
+  def recent_media_with_pagination(tag_name, params, token \\ :global) do
     accepted = [:count, :min_tag_id, :max_tag_id]
     request_params = parse_request_params(params, accepted)
-    get("/tags/#{tag_name}/media/recent", token, request_params).data |> Enum.map(&parse_media(&1))
+    get("/tags/#{tag_name}/media/recent", token, request_params)
   end
 end

--- a/test/elixtagram_test.exs
+++ b/test/elixtagram_test.exs
@@ -122,6 +122,18 @@ defmodule ElixtagramTest do
     end
   end
 
+  test "get recent media and pagination data from a tag (unauthenticated)" do
+    tag = "ts"
+    use_cassette "tag_recent_media" do
+      %{data: medias, pagination: %{next_max_id: next_max_id}} =
+        Elixtagram.tag_recent_media_with_pagination(tag, %{count: 10})
+      media = List.first(medias)
+      assert length(medias) > 0
+      assert Enum.member?(media.tags, "ts")
+      assert next_max_id == "1084955995775571154"
+    end
+  end
+
   test "get recent media from a tag (implicitly authenticated)" do
     tag = "ts"
     token = System.get_env("INSTAGRAM_ACCESS_TOKEN")
@@ -148,6 +160,20 @@ defmodule ElixtagramTest do
       media = List.first(medias)
       assert length(medias) > 0
       assert Enum.member?(media.tags, "ts")
+    end
+  end
+
+  test "get recent media and pagination data from a tag (explicitly authenticated)" do
+    tag = "ts"
+    token = System.get_env("INSTAGRAM_ACCESS_TOKEN")
+
+    use_cassette "tag_recent_media" do
+      %{data: medias, pagination: %{next_max_id: next_max_id}} =
+        Elixtagram.tag_recent_media_with_pagination(tag, %{count: 10}, token)
+      media = List.first(medias)
+      assert length(medias) > 0
+      assert Enum.member?(media.tags, "ts")
+      assert next_max_id == "1084955995775571154"
     end
   end
 


### PR DESCRIPTION
Hi. I need to paginate over `tag_recent_media`, but it suppresses `next_max_id` param from `/tags/tag-name/media/recent` response.

In this PR function `Elixtagram.tag_recent_media_with_pagination` has been implemented. It returns media data with pagination information.