### PR TITLE
Fix response handling for exceeded limit

### DIFF
--- a/fixture/vcr_cassettes/limit_exceeded.json
+++ b/fixture/vcr_cassettes/limit_exceeded.json
@@ -1,0 +1,29 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": [],
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.instagram.com/v1/tags/capybara/media/recent"
+    },
+    "response": {
+      "body": "{\"error_type\": \"OAuthRateLimitException\", \"code\": 429, \"error_message\": \"You have exceeded the maximum number of requests per hour. You have performed a total of 5007 requests in the last hour. Our general maximum limit is set at 5000 requests per hour.\"}",
+      "headers": {
+        "Content-Type": "application/json",
+        "Cache-Control": "private, no-cache, no-store, must-revalidate",
+        "Pragma": "no-cache",
+        "Expires": "Sat, 01 Jan 2000 00:00:00 GMT",
+        "Vary": "Accept-Language, Cookie",
+        "Content-Language": "en",
+        "Date": "Wed, 19 Apr 2017 19:59:15 GMT",
+        "Set-Cookie": "rur=PRN; Path=/",
+        "Connection": "keep-alive",
+        "Content-Length": "255"
+      },
+      "status_code": 429,
+      "type": "ok"
+    }
+  }
+]

--- a/lib/elixtagram/api/base.ex
+++ b/lib/elixtagram/api/base.ex
@@ -41,9 +41,15 @@ defmodule Elixtagram.API.Base do
 
   defp handle_response(data) do
     response = Poison.decode!(data.body, keys: :atoms)
-    case response.meta.code do
-      200 -> response
-      _ -> raise(Elixtagram.Error, [code: response.meta.code, message: "#{response.meta.error_type}: #{response.meta.error_message}"])
+    case response do
+      %{code: 200} ->
+        response
+      %{code: code} ->
+        raise(Elixtagram.Error, [code: code, message: "#{response.error_type}: #{response.error_message}"])
+      %{meta: %{code: 200}} ->
+        response
+      %{meta: %{code: code}} ->
+        raise(Elixtagram.Error, [code: code, message: "#{response.meta.error_type}: #{response.meta.error_message}"])
     end
   end
 

--- a/test/elixtagram_test.exs
+++ b/test/elixtagram_test.exs
@@ -938,4 +938,14 @@ defmodule ElixtagramTest do
       assert response == :ok
     end
   end
+
+  test "exceeded the maximum number of requests per hour" do
+    token = "XXXXXXXXXX"
+
+    use_cassette "limit_exceeded" do
+      assert_raise Elixtagram.Error, fn ->
+        Elixtagram.tag_recent_media("capybara", %{}, token)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hello. Today my app exceeded API limit, it let me to the bug in elixtagram: 
```
(KeyError) key :meta not found in: %{code: 429, error_message: "You have exceeded the maximum number of requests per hour. You have performed a total of 5004 requests in the last hour. Our general maximum limit is set at 5000 requests per hour.", error_type: "OAuthRateLimitException"}
(elixtagram) lib/elixtagram/api/base.ex:44: Elixtagram.API.Base.handle_response/1
```
It seems that when limit is exceeded, Instagram API doesn't pack error's code and message in the `meta` field. Here is the example API response:
```
"response": {
    "body": "{\"error_type\": \"OAuthRateLimitException\", \"code\": 429, \"error_message\": \"You have exceeded the maximum number of requests per hour. You have performed a total of 5007 requests in the last hour. Our general maximum limit is set at 5000 requests per hour.\"}"
}
```

In this PR response handling has been fixed, so this and other potential similar cases will be parsed correctly. 