### PR TITLE
add carousel_media type

### DIFF
--- a/lib/elixtagram/model.ex
+++ b/lib/elixtagram/model.ex
@@ -14,7 +14,7 @@ defmodule Elixtagram.Model.Media do
   defstruct attribution: nil, id: nil, caption: nil, comments: nil, type: nil,
             images: nil, likes: nil, link: nil, location: nil, tags: nil,
             user: nil, filter: nil, created_time: nil, users_in_photo: nil,
-            videos: nil
+            videos: nil, carousel_media: nil
 end
 
 defmodule Elixtagram.Model.Location do


### PR DESCRIPTION
On Apr 18, 2017 support for carousel formats [was added to instagram API](https://www.instagram.com/developer/changelog/).

In this PR `carousel_media` field has been added to `%Elixtagram.Model.Media`.

Example response for carousel media:
```
carousel_media: [%{images: %{low_resolution: %{height: 320,
         url: "https://scontent.cdninstagram.com/t51.2885-15/s320x320/e35/17076278_251021678679060_9102254500273455104_n.jpg",
         width: 320},
       standard_resolution: %{height: 640,
         url: "https://scontent.cdninstagram.com/t51.2885-15/s640x640/sh0.08/e35/17076278_251021678679060_9102254500273455104_n.jpg",
         width: 640},
       thumbnail: %{height: 150,
         url: "https://scontent.cdninstagram.com/t51.2885-15/s150x150/e35/17076278_251021678679060_9102254500273455104_n.jpg",
         width: 150}}, type: "image", users_in_photo: []},
   %{images: %{low_resolution: %{height: 320,
         url: "https://scontent.cdninstagram.com/t51.2885-15/s320x320/e35/15538303_761651270670683_7382064641607729152_n.jpg",
         width: 320},
       standard_resolution: %{height: 640,
         url: "https://scontent.cdninstagram.com/t51.2885-15/s640x640/sh0.08/e35/15538303_761651270670683_7382064641607729152_n.jpg",
         width: 640},
       thumbnail: %{height: 150,
         url: "https://scontent.cdninstagram.com/t51.2885-15/s150x150/e35/15538303_761651270670683_7382064641607729152_n.jpg",
         width: 150}}, type: "image", users_in_photo: []}]
```